### PR TITLE
schemaregistry/serde/protobuf: add schema registry metadata cache

### DIFF
--- a/schemaregistry/serde/protobuf/protobuf.go
+++ b/schemaregistry/serde/protobuf/protobuf.go
@@ -152,11 +152,16 @@ func (s *Deserializer) ConfigureDeserializer(client schemaregistry.Client, serde
 	return nil
 }
 
+// RegisterDataType resolves message dependencies to build schema registry metadata, then add it to local cache.
+// Must call this method before you want to call Serialize for corresponding message data type
 func (s *Serializer) RegisterDataType(message proto.Message) error {
 	descName := string(message.ProtoReflect().Descriptor().FullName().Name())
 	metadata, ok := s.cachedMetadata[descName]
 	if !ok {
 		messageDesc, err := desc.LoadMessageDescriptorForMessage(protoV1.MessageV1(message))
+		if err != nil {
+			return err
+		}
 		fileDesc, deps, err := s.toProtobufSchema(messageDesc)
 		if err != nil {
 			return err

--- a/schemaregistry/serde/protobuf/protobuf_test.go
+++ b/schemaregistry/serde/protobuf/protobuf_test.go
@@ -36,6 +36,9 @@ func TestProtobufSerdeWithSimple(t *testing.T) {
 	ser, err := NewSerializer(client, serde.ValueSerde, NewSerializerConfig())
 	serde.MaybeFail("Serializer configuration", err)
 
+	err = ser.RegisterDataType(&test.Author{})
+	serde.MaybeFail("Serializer registers data type", err)
+
 	obj := test.Author{
 		Name:  "Kafka",
 		Id:    123,
@@ -65,6 +68,9 @@ func TestProtobufSerdeWithSecondMessage(t *testing.T) {
 	ser, err := NewSerializer(client, serde.ValueSerde, NewSerializerConfig())
 	serde.MaybeFail("Serializer configuration", err)
 
+	err = ser.RegisterDataType(&test.Pizza{})
+	serde.MaybeFail("Serializer registers data type", err)
+
 	obj := test.Pizza{
 		Size:     "Extra extra large",
 		Toppings: []string{"anchovies", "mushrooms"},
@@ -93,6 +99,9 @@ func TestProtobufSerdeWithNestedMessage(t *testing.T) {
 	ser, err := NewSerializer(client, serde.ValueSerde, NewSerializerConfig())
 	serde.MaybeFail("Serializer configuration", err)
 
+	err = ser.RegisterDataType(&test.NestedMessage_InnerMessage{})
+	serde.MaybeFail("Serializer registers data type", err)
+
 	obj := test.NestedMessage_InnerMessage{
 		Id: "inner",
 	}
@@ -119,6 +128,9 @@ func TestProtobufSerdeWithReference(t *testing.T) {
 
 	ser, err := NewSerializer(client, serde.ValueSerde, NewSerializerConfig())
 	serde.MaybeFail("Serializer configuration", err)
+
+	err = ser.RegisterDataType(&test.DependencyMessage{})
+	serde.MaybeFail("Serializer registers data type", err)
 
 	msg := test.TestMessage{
 		TestString:   "hi",
@@ -164,6 +176,9 @@ func TestProtobufSerdeWithCycle(t *testing.T) {
 
 	ser, err := NewSerializer(client, serde.ValueSerde, NewSerializerConfig())
 	serde.MaybeFail("Serializer configuration", err)
+
+	err = ser.RegisterDataType(&test.LinkedList{})
+	serde.MaybeFail("Serializer registers data type", err)
 
 	inner := test.LinkedList{
 		Value: 100,


### PR DESCRIPTION
schemaregistry/serde/protobuf: add schema registry metadata cache

Using the same benchmark script from https://orange-v2.atlassian.net/browse/TM-590?focusedCommentId=10226

```
(venv) envyt@ubuntu ~/go/src/github.com/onebrunchman/orange-v2-go-backend/kafka/producer (thangng48/send-processed-message) $ go test -bench=.  -benchtime=5s
{"level":"info","ts":"2022-08-22T18:38:35.639+0700","caller":"logging/logger.go:41","msg":"New logger created by using zap.NewProductionConfig() function."}
goos: linux
goarch: amd64
pkg: github.com/orange-v2/orange-v2-go-backend/kafka/producer
cpu: AMD Ryzen 9 5900HS with Radeon Graphics        
BenchmarkSchemaRegistryProto-8            189660             29944 ns/op
```


Fixes [TM-615]

Signed-off-by: Thang Nguyen <thangng48@gmail.com>

[TM-615]: https://orange-v2.atlassian.net/browse/TM-615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ